### PR TITLE
docker_compose_command: Accept 'docker compose' in config

### DIFF
--- a/doxy/services.py
+++ b/doxy/services.py
@@ -41,5 +41,5 @@ def get_compose_file(service_path: Path) -> Path:
 def docker_compose_command(commands: List[str], compose_file: Path):
     ctx = click.get_current_context()
     config = ctx.obj["CONFIG"]
-    cmd = [config.compose_executable, "-f", compose_file] + list(commands)
+    cmd = config.compose_executable.split() + ["-f", compose_file] + list(commands)
     subprocess.run(cmd)


### PR DESCRIPTION
By splitting the command, we create a list that can be used with subprocess.run(). This allows to use simple paths as well as command-lines like "docker compose" to be specified in compose_executable. It also allows to pass more arguments to the process.

This doesn't take into account any logic used by shells to quote strings or escape characters. We could use shlex.split() instead, if that's required.